### PR TITLE
rposition() -> rev().position()

### DIFF
--- a/src/libstd/sys_common/backtrace.rs
+++ b/src/libstd/sys_common/backtrace.rs
@@ -154,7 +154,7 @@ fn filter_frames(frames: &[Frame],
     let skipped_before = frames.iter().position(|frame| {
         is_good_frame(*frame, BAD_PREFIXES_TOP)
     }).unwrap_or(frames.len());
-    let skipped_after = frames[skipped_before..].iter().rposition(|frame| {
+    let skipped_after = frames[skipped_before..].iter().rev().position(|frame| {
         is_good_frame(*frame, BAD_PREFIXES_BOTTOM)
     }).unwrap_or(frames.len() - skipped_before);
 


### PR DESCRIPTION
`rposition` turned out to do completely different thing than I thought, this caused Travis failure in https://github.com/rust-lang/rust/pull/38165.
When you merge this, I will r+ https://github.com/rust-lang/rust/pull/38165.